### PR TITLE
ci(dependabot): drop [ci skip] prefix on actions bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,5 +16,3 @@ updates:
           all-actions:
               patterns:
                   - "*"
-      commit-message:
-          prefix: "[ci skip]"


### PR DESCRIPTION
The `[ci skip]` commit-message prefix causes GitHub Actions to skip all workflows on the resulting PRs (including `pull_request` triggers), which leaves required status checks pending forever and blocks merging. Let actions bumps run CI like every other PR.