### PR TITLE
ci: ignore CVE-2026-3219 in pip 26.0.1

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Pip-audit
         if: matrix.python-version == '3.12'
-        run: uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645  # pygments 2.19.2 + requests 2.32.5, no fix available yet
+        run: uv run pip-audit --ignore-vuln CVE-2026-4539 --ignore-vuln CVE-2026-25645 --ignore-vuln CVE-2026-3219  # pygments 2.19.2 + requests 2.32.5 + pip 26.0.1, no fix available yet
 
   release:
     name: Semantic Release


### PR DESCRIPTION
## Summary
- Adds `--ignore-vuln CVE-2026-3219` to the pip-audit step.
- pip 26.0.1 has CVE-2026-3219 with no fix available yet (uv ships this version).

## Why
After merging the dependabot all-deps PR (#74), pip-audit started flagging pip itself, blocking the remaining dependabot PRs (#73, #76).

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)