### PR TITLE
ci: pin BuildKit to v0.29.0 (clears Scout Go stdlib CVEs)

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -109,6 +109,8 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+        with:
+          driver-opts: image=moby/buildkit:v0.29.0
 
       - name: Docker meta
         id: meta


### PR DESCRIPTION
Pins BuildKit to v0.29.0 (Go 1.26.1) so the SBOM/provenance attestations no longer reference a vulnerable Go stdlib. Resolves the bulk of the Docker Scout C/D health-grade CVEs (golang/stdlib 1.24.4).