### PR TITLE
chore: replace gosu with setpriv (eliminates Go-stdlib CVEs from SBOM)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ ENV APP_PRETEND_VERSION=${VERSION}
 # ===== System Dependencies =====
 RUN apt-get update && \
     apt-get upgrade -y && \
-    apt-get install -y --no-install-recommends git gosu && \
+    apt-get install -y --no-install-recommends git && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir uv && \
     rm -rf /var/lib/apt/lists/*

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ if [ "$(id -u)" = "0" ]; then
 
     chown appuser:appuser /app /config /media
 
-    exec gosu appuser "$@"
+    exec setpriv --reuid=appuser --regid=appuser --init-groups "$@"
 fi
 
 # Already running as non-root (no PUID/PGID support)


### PR DESCRIPTION
## Summary
gosu (a Go binary) is the only Go-built file in the image. Its embedded Go stdlib is the source of all the \`golang/stdlib 1.24.4\` CVEs Docker Scout has been reporting — driving the health grade to D.

\`setpriv --reuid=appuser --regid=appuser --init-groups \"\$@\"\` does the same job (drop privs from root after PUID/PGID adjust), is part of \`util-linux\` already in the python:3-slim base image, and is a C binary — so the image is Go-binary-free.

This is the pattern already used in \`vision2mqtt\`, which sits at C in Scout vs. D for the gosu-using siblings.

## Test plan
- [ ] Image builds
- [ ] Container starts as appuser when PUID/PGID env is set
- [ ] Container starts as appuser when PUID/PGID env is unset (defaults 1000:1000)
- [ ] Scout grade improves on next rebuild