### PR TITLE
fix: silence benign blinkpy 'last records' ERROR log spam

### DIFF
--- a/src/blink2mqtt/app.py
+++ b/src/blink2mqtt/app.py
@@ -8,6 +8,14 @@ from mqtt_helper import ConfigError, MqttError
 from .core import Blink2Mqtt
 
 
+class BlinkpyRecordsNoiseFilter(logging.Filter):
+    # blinkpy/camera.py (0.25.5) guards last_records with `len(dict) > 0` then indexes
+    # by camera name, so a camera with no records but a recorded sibling raises KeyError,
+    # which blinkpy catches and re-logs at ERROR on every refresh. Upstream bug; drop it.
+    def filter(self, record: logging.LogRecord) -> bool:
+        return "Error getting last records" not in record.getMessage()
+
+
 def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(prog="blink2mqtt", exit_on_error=True)
     p.add_argument(
@@ -22,6 +30,7 @@ def build_parser() -> argparse.ArgumentParser:
 async def async_main() -> int:
     setup_logging()
     logging.getLogger("blinkpy.camera").setLevel(logging.WARNING)
+    logging.getLogger("blinkpy.camera").addFilter(BlinkpyRecordsNoiseFilter())
     logger = get_logger(__name__)
 
     parser = build_parser()


### PR DESCRIPTION
## Summary
- A camera with no recent records but a recorded sibling triggers a `KeyError` in the blinkpy dependency (`camera.py` `update_images`), which blinkpy catches and re-logs at **ERROR** on every refresh — ~1,500 lines/day for a single camera in production.
- Root cause is upstream: blinkpy 0.25.5 guards `last_records` with `len(dict) > 0` and then indexes by camera name instead of checking key membership. It's benign (no records = no clips), but floods the logs.
- The existing `logging.getLogger("blinkpy.camera").setLevel(logging.WARNING)` can't suppress it because the record is emitted at ERROR (above WARNING). This adds a targeted `logging.Filter` that drops only this specific message while still letting genuine `blinkpy.camera` errors through.

## Test plan
- [x] Unit-verified the filter drops the real message format (`Error getting last records for '%s': %s`) and keeps unrelated `blinkpy.camera` errors (e.g. "Could not find thumbnail...").
- [ ] Confirm the `Error getting last records` ERROR lines stop appearing in logs after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)